### PR TITLE
German translation should be called "deutsch"

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@ What small-scale interaction will you make today, little firefly?
 	<a href="http://ncase.me/fireflies-zh/">中文 (chinese)</a><br>
 	<a href="http://ncase.me/fireflies-pt-br/">português (brazilian portuguese)</a><br>
 	<a href="http://ncase.me/fireflies-fr/">français (french)</a><br>
-	<a href="http://ncase.me/fireflies-de/">deutsche (german)</a><br>
+	<a href="http://ncase.me/fireflies-de/">deutsch (german)</a><br>
 	<a href="http://ncase.me/fireflies-tr/">türkçe (turkish)</a><br>
 	<a href="https://alxliv.github.io/fireflies/">pусский (russian)</a><br>
 	<a href="https://taleinat.github.io/fireflies/">עברית (hebrew)</a>


### PR DESCRIPTION
"deutsche" is adjective form and only makes sense if you combine it with another word like "deutsche Sprache" ("German language"), otherwise it should just be "deutsch" ("German").